### PR TITLE
Roman numerals instead of month name for Polish language

### DIFF
--- a/back/language_data/pl.json
+++ b/back/language_data/pl.json
@@ -40,18 +40,18 @@
     "watchpageUploadDate": {
         "dateFormat": "[day] [monthcode] [year]",
         "monthcodes": {
-            "Jan": "sty",
-            "Feb": "lut",
-            "Mar": "mar",
-            "Apr": "kwi",
-            "May": "maj",
-            "Jun": "cze",
-            "Jul": "lip",
-            "Aug": "sie",
-            "Sep": "wrz",
-            "Oct": "paź",
-            "Nov": "lis",
-            "Dec": "gru"
+            "Jan": "I",
+            "Feb": "II",
+            "Mar": "III",
+            "Apr": "IV",
+            "May": "V",
+            "Jun": "VI",
+            "Jul": "VII",
+            "Aug": "VIII",
+            "Sep": "IX",
+            "Oct": "X",
+            "Nov": "XI",
+            "Dec": "XII"
         }
     },
     "subscribe": "Subskrybuj",


### PR DESCRIPTION
It was really like this in 2009. Here's the proof:
![uid_edb6f8db720b3d8c466d3717358612ac1235315526987_width_969_play_0_pos_0_gs_0_height_727](https://github.com/ftde0/yt2009/assets/81510862/822af49e-69bb-4d60-8515-7a4e8b8ceaad)