### PR TITLE
fix redirMode

### DIFF
--- a/back/backend.js
+++ b/back/backend.js
@@ -1915,6 +1915,24 @@ app.post("/youtube/accounts/registerDevice", (req, res) => {
     res.send(`DeviceId=${deviceId}
 DeviceKey=ULxlVAAVMhZ2GeqZA/X1GgqEEIP1ibcd3S+42pkWfmk=`)
 })
+//using GET this time
+app.get("/youtube/accounts/registerDevice", (req, res) => {
+    let deviceId = ""
+    while(deviceId.length !== 7) {
+        deviceId += "qwertyuiopasdfghjklzxcvbnm1234567890".split("")
+                    [Math.floor(Math.random() * 36)]
+    }
+    while(useMobileHelper && mobileHelper.hasLogin(deviceId)) {
+        deviceId = ""
+        while(deviceId.length !== 7) {
+            deviceId += "qwertyuiopasdfghjklzxcvbnm1234567890".split("")
+                        [Math.floor(Math.random() * 36)]
+        }
+    } 
+    res.send(`DeviceId=${deviceId}
+DeviceKey=ULxlVAAVMhZ2GeqZA/X1GgqEEIP1ibcd3S+42pkWfmk=`)
+})
+
 app.get("/feeds/api/standardfeeds/*", (req, res) => {
     yt2009_mobile.feeds(req, res)
 })


### PR DESCRIPTION
YouTube app changes method from POST to GET if a redirection happens, meaning registerDevice calls now get a 404 response.
This causes the app to show the "There was an error starting up." error message, unless the device registered before. In which case, the app continues to function normally, as it uses the cached ID and key.