### PR TITLE
Implement device registration endpoint for RedirMode

### DIFF
--- a/back/backend.js
+++ b/back/backend.js
@@ -2778,6 +2778,26 @@ app.post("/youtube/accounts/registerDevice", (req, res) => {
     res.send(`DeviceId=${deviceId}
 DeviceKey=ULxlVAAVMhZ2GeqZA/X1GgqEEIP1ibcd3S+42pkWfmk=`)
 })
+app.get("/youtube/accounts/registerDevice", (req, res) => {
+    let deviceId = ""
+    while(deviceId.length !== 7) {
+        deviceId += "qwertyuiopasdfghjklzxcvbnm1234567890".split("")
+                    [Math.floor(Math.random() * 36)]
+    }
+    while(useMobileHelper && mobileHelper.hasLogin(deviceId)) {
+        deviceId = ""
+        while(deviceId.length !== 7) {
+            deviceId += "qwertyuiopasdfghjklzxcvbnm1234567890".split("")
+                        [Math.floor(Math.random() * 36)]
+        }
+    } 
+    /* This is required for RedirMode to work. Without the same function with GET instead of POST, all 
+	clients connecting for the first time will error out during initialization.
+    
+    #yt2009 - devicekey created with aes secret from 2.3.4 apk*/
+    res.send(`DeviceId=${deviceId}
+DeviceKey=ULxlVAAVMhZ2GeqZA/X1GgqEEIP1ibcd3S+42pkWfmk=`)
+})
 app.get("/feeds/api/standardfeeds/*", (req, res) => {
     yt2009_mobile.feeds(req, res)
 })


### PR DESCRIPTION
The YouTube client switches protocols from POST to GET if a redirection happens during the first time initialization. Therefore, clients cannot be registered if a yt2009 server redirects it to another yt2009 server, since the forwarded server won't have any matching endpoints for GET /youtube/accounts/registerDevice. This causes clients to never start up and use any functionality on the app at all.