### PR TITLE
feat(mobile): implement MPEG-4 codec

### DIFF
--- a/back/backend.js
+++ b/back/backend.js
@@ -3078,7 +3078,8 @@ let videoProcessEndpoints = [
     "/mp4_144",
     "/http_3gp",
     "/http_wmv",
-    "/http_xvid"
+    "/http_xvid",
+    "/http_mpeg4"
 ]
 videoProcessEndpoints.forEach(endpoint => {
     app.get(endpoint, (req, res) => {

--- a/back/yt2009mobile.js
+++ b/back/yt2009mobile.js
@@ -59,6 +59,18 @@ const ffmpeg_process_xvid = [
     "-vf scale=640:480",
     "\"$2\""
 ]
+const ffmpeg_process_mpeg4 = [
+    "ffmpeg",
+    "-i \"$1\"",
+    "-c:v mpeg4",
+    "-vtag mp4v",
+    "-b:v 501k",
+    "-brand isom",
+    "-pix_fmt yuv420p",
+    "-c:a copy",
+    "-f mp4",
+    "\"$2\""
+]
 const ffmpeg_stream_mp4 = [
     "ffmpeg",
     "-re -i",
@@ -275,7 +287,8 @@ module.exports = {
                 case "http_3gp":
                 case "http_wmv":
                 case "http_mp4_144":
-                case "http_xvid": {
+                case "http_xvid":
+                case "http_mpeg4": {
                     playback = method;
                 }
             }
@@ -290,7 +303,8 @@ module.exports = {
             "http_mp4_144": [ffmpeg_process_144, "id-144.mp4"],
             "http_3gp": [ffmpeg_process_3gp, "id.3gp"],
             "http_wmv": [ffmpeg_process_wmv, "id.wmv"],
-            "http_xvid": [ffmpeg_process_xvid, "id.avi"]
+            "http_xvid": [ffmpeg_process_xvid, "id.avi"],
+            "http_mpeg4": [ffmpeg_process_mpeg4, "id-mpeg4.mp4"]
         }
 
         let tasks = taskLookup[playback]
@@ -482,6 +496,7 @@ module.exports = {
             "http_3gp": "/http_3gp?v=" + id,
             "http_wmv": "/http_wmv?v=" + id,
             "http_xvid": "/http_xvid?v=" + id,
+            "http_mpeg4": "/http_mpeg4?v=" + id,
             "http_flash_flv": "/mobile/watch?v=" + id,
             "http_flash_mp4": "/mobile/watch?v=" + id
         }

--- a/mobile/playback_setup.htm
+++ b/mobile/playback_setup.htm
@@ -20,6 +20,7 @@
     <button onclick="setPlayback('http_3gp')">HTTP / 3GP</button><br>
     <button onclick="setPlayback('http_wmv')">HTTP / LQ/WMV</button><br>
     <button onclick="setPlayback('http_xvid')">HTTP / XVID</button><br>
+    <button onclick="setPlayback('http_mpeg4')">HTTP / MPEG-4</button><br>
     <button onclick="setPlayback('http_flash_flv')">HTTP / FLASH / FLV</button><br>
     <button onclick="setPlayback('http_flash_mp4')">HTTP / FLASH / H264 MP4</button><br>
     <h3 style="margin-top: 20px;">bonus: toggle old_experience: exp_related and only_old together.</h3>

--- a/mobile/playback_setup_basic.htm
+++ b/mobile/playback_setup_basic.htm
@@ -28,7 +28,9 @@
         <input type="radio" id="http_wmv" value="http_wmv" name="playback_option">
         <label for="http_wmv">HTTP / LQ/WMV</label><br>
         <input type="radio" id="http_xvid" value="http_xvid" name="playback_option">
-        <label for="http_xvid">HTTP / XVID</label><br><br>
+        <label for="http_xvid">HTTP / XVID</label><br>
+        <input type="radio" id="http_mpeg4" value="http_mpeg4" name="playback_option">
+        <label for="http_mpeg4">HTTP / MPEG-4</label><br><br>
         <input type="radio" id="http_flash_flv" value="http_flash_flv" name="playback_option">
         <label for="http_flash_flv">HTTP / FLASH / FLV</label><br><br>
         <input type="radio" id="http_flash_mp4" value="http_flash_mp4" name="playback_option">


### PR DESCRIPTION
This PR implements the MPEG-4 codec. While yt2009 already supports the Xvid codec in AVI format which is an implementation of the same MPEG-4 Part 2 spec, there is no MPEG-4 support in MP4 format yet. MPEG-4 may be very useful for ARMv5/v6 devices running Android 1.0–2.3, as H.264 Constrained Baseline doesn't always work and there is no native AVI support.